### PR TITLE
Fix errors in Python 3.8

### DIFF
--- a/moshmosh/extensions/quick_lambdas.py
+++ b/moshmosh/extensions/quick_lambdas.py
@@ -70,7 +70,8 @@ class QuickLambdaDetector(ast.NodeTransformer):
                         argcount = cur_collector.max_arg_index + 1
                         return ast.Lambda(
                             ast.arguments(
-                                [
+                                posonlyargs=[],
+                                args=[
                                     ast.arg(
                                         '.' + cur_collector.mk_arg(i),
                                         annotation=None

--- a/tests/py35_unparse.py
+++ b/tests/py35_unparse.py
@@ -316,6 +316,9 @@ class Unparser:
         self.leave()
 
     # expr
+    def _Constant(self, t):
+        self.write(repr(t.s))
+
     def _Bytes(self, t):
         self.write(repr(t.s))
 


### PR DESCRIPTION
This PR fixes errors in Python 3.8 to make moshmosh pass the tests.

The error in quick lambda is caused by [positional-only-parameters](https://docs.python.org/3.8/whatsnew/3.8.html#positional-only-parameters).

The error in py35_unparse.py is caused by [3.8#deprecated](https://docs.python.org/3.8/whatsnew/3.8.html#deprecated):
> ast classes Num, Str, Bytes, NameConstant and Ellipsis are considered deprecated and will be removed in future Python versions. Constant should be used instead. (Contributed by Serhiy Storchaka in bpo-32892.)

This patch should also be compatible with version < 3.8.